### PR TITLE
Fix typo at view and use placeholder

### DIFF
--- a/app/views/twilio/broadcast.html.erb
+++ b/app/views/twilio/broadcast.html.erb
@@ -24,10 +24,10 @@
       <p class="recording-status help-block"></p>
     </div>
   </div>
-  <h3>2. Enter a list of phone_numbers</h3>
+  <h3>2. Enter a list of phone numbers</h3>
   <div class="form-group">
     <div class="col-sm-5">
-      <textarea class="form-control" id="phone-numbers" name="numbers" rows="5" >Enter a comma separated list. Example: 5558675309, 2065554420</textarea>
+      <textarea class="form-control" id="phone-numbers" name="numbers" placeholder="Enter a comma separated list. Example: 5558675309, 2065554420" rows="5" ></textarea>
     </div>
   </div>
   <button type="submit" class="btn btn-square">Submit</button>


### PR DESCRIPTION
@jarodreyes, the application looks really good! I really like the UI, makes me feel in love with **RAPID RESPONSE KIT** :smiley:

I've just fixed a minor typo at broadcast view and display the same text you already have as a _placeholder_, I think that was the original intention, right?

![rapid_response_-_conferencing_and_broadcasting_kit](https://cloud.githubusercontent.com/assets/957202/10164987/5a11ef84-6682-11e5-99ca-fae9023aa409.png)