### PR TITLE
Cleanup broadcast.js

### DIFF
--- a/app/assets/javascripts/broadcast.js
+++ b/app/assets/javascripts/broadcast.js
@@ -3,7 +3,7 @@ $(function() {
   var getRecordings, lastRecording, populateSelect, showRecordings, updateAudio;
 
   lastRecording = new Date('2000-09-27');
-  
+
   getRecordings = function(callback) {
     return $.ajax({
       url: "/fetch_recordings",
@@ -19,40 +19,40 @@ $(function() {
       }
     });
   };
-  
+
   showRecordings = function(recordings) {
     var newestRecording;
     newestRecording = new Date(recordings[0]['date']);
-  
+
     if (newestRecording > lastRecording) {
       lastRecording = newestRecording;
       return populateSelect(recordings);
     }
   };
-  
+
   populateSelect = function(recordings) {
     var recording, select, _i, _len, _results;
     select = $('#selectRecordings');
     select.empty();
     _results = [];
-  
+
     for (_i = 0, _len = recordings.length; _i < _len; _i++) {
       recording = recordings[_i];
       _results.push((function(recording) {
         return select.append($("<option></option>").val(recording.url).html(recording.date));
       })(recording));
     }
-  
+
     return _results;
   };
-  
+
   updateAudio = function() {
     var selectedUrl;
     selectedUrl = $('#selectRecordings option:selected').val();
     $('#recording-audio').attr('src', selectedUrl);
     return $('#recording-url').attr('value', selectedUrl);
   };
-  
+
   $('.call-me').click(function(e) {
     var phoneNumber;
     e.preventDefault();
@@ -68,25 +68,24 @@ $(function() {
       })(this), 20000);
     });
   });
-  
+
   $('.show-make').click(function(e) {
     e.preventDefault();
     return $('.make-recording').toggleClass('slide-down');
   });
-  
+
   $('#selectRecordings').on('change', 'click', function(e) {
     return getRecordings(updateAudio);
   });
-  
+
   $('.preview-btn').click(function(e) {
     e.preventDefault();
     return document.getElementById('recording-audio').play();
   });
-  
+
   return $(document).ready(function() {
     if (window.location.pathname === '/broadcast') {
       getRecordings(updateAudio);
     }
-    return console.log(window.location.pathname);
   });
 });


### PR DESCRIPTION
@jarodreyes I like how `broadcast.js` is organized.

This is just a cleanup: 
1. Removed the spaces left in the separation lines.
2. I guess is ok to remove `return console.log(window.location.pathname);` from `$(document).ready...`

What do you think?